### PR TITLE
Handle HTTP errors

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -11,6 +11,13 @@ type Error struct {
 	} `json:"source"`
 }
 
-func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Title, e.Detail)
+type Errors struct {
+	Errors []Error `json:"errors"`
+}
+
+func (e *Errors) Error() error {
+	if len(e.Errors) > 0 {
+		return fmt.Errorf("%d: %s", e.Errors[0].Status, e.Errors[0].Detail)
+	}
+	return fmt.Errorf("No errors")
 }


### PR DESCRIPTION
The error handling seemed to be somewhat broken. The client would retry on 404 errors. This PR fixes the issue.